### PR TITLE
Part for fix for "Not compatible with referenced subsystems #2" bug

### DIFF
--- a/src/GenSDD.m
+++ b/src/GenSDD.m
@@ -12,6 +12,8 @@ function GenSDD(topsys)
     
     %
     saved_workspace = SaveAndClearBaseVars('pre-sdd-gen'); % Saves base workspace variables in mat file
+    [modelpath,~,~] = fileparts(which(topsys));
+    cd(modelpath); % Make sure pwd is folder of opened model
     
     %
     assignin('base', 'topsys', topsys);


### PR DESCRIPTION
Added code to switch pwd to path of simulink model at start of GenSDD.m script.

Bug fix also requires change to code in the Simulink-Utilities sub project.

Suspect it is due to a Matlab bug where changing the pwd from the Simulink model's directory causes find_system() to return different systems compared to if the pwd is in the model's directory. This applies to a file in the utilities folder at the path Simulink-Utility\DataflowTracing\inoutblock2subport.m